### PR TITLE
Change type of hash_key_t to avoid unnecessary casts

### DIFF
--- a/dhash/dhash.c
+++ b/dhash/dhash.c
@@ -176,7 +176,7 @@ static void sys_free_wrapper(void *ptr, void *pvt)
 static address_t convert_key(hash_key_t *key)
 {
     address_t h;
-    unsigned char *k;
+    const unsigned char *k;
 
     switch(key->type) {
     case HASH_KEY_ULONG:
@@ -184,7 +184,7 @@ static address_t convert_key(hash_key_t *key)
         break;
     case HASH_KEY_STRING:
         /* Convert string to integer */
-        for (h = 0, k = (unsigned char *) key->str; *k; k++)
+        for (h = 0, k = (const unsigned char *)key->str; *k; k++)
             h = h * PRIME_1 ^ (*k - ' ');
         break;
     default:

--- a/dhash/dhash.h
+++ b/dhash/dhash.h
@@ -136,7 +136,7 @@ typedef enum
 typedef struct hash_key_t {
     hash_key_enum type;
     union {
-        char *str;
+        const char *str;
         unsigned long ul;
     };
 } hash_key_t;


### PR DESCRIPTION
We'll add "const" because hashing shouldn't involve modifying the keys
themselves (that would be bad).

Note: this will generate warnings for the memcpy() to initialize the key and for calls to hfree().  We could make these go away with pragma's to ignore the warnings (-Wcast-qual), but that would not be portable.
