### PR TITLE
ini: Enlarge buffer length to accommodate larger values

### DIFF
--- a/ini/ini_defines.h
+++ b/ini/ini_defines.h
@@ -66,7 +66,7 @@
 #define INI_SECTION_KEY "["
 
 /* Internal sizes. MAX_KEY is defined in config.h */
-#define MAX_VALUE       PATH_MAX
+#define MAX_VALUE       (PATH_MAX + 4096)
 #define BUFFER_SIZE     MAX_KEY + MAX_VALUE + 3
 
 /* Beffer length used for int to string conversions */


### PR DESCRIPTION
While a 4 KB buffer is usually generous enough, sometimes user may wish to
read an even longer value. Before a dynamic allocation of the value buffer
is implemented, temporarily increase the buffer by a futher 4 KB.
