### PR TITLE
Portability fixes (and some tidyup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ Makefile.in.in
 autom4te.cache
 libtool
 stamp-h1
-m4/
+m4/*
+!m4/ld-version-script.m4
 aclocal.m4
 depcomp
 ltmain.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -306,8 +306,10 @@ libini_config_la_LIBADD = \
     libcollection.la \
     libpath_utils.la \
     libref_array.la \
-    libbasicobjects.la
-libini_config_la_LDFLAGS = $(LIBICONV) $(LIBINTL)\
+    libbasicobjects.la \
+    $(LTLIBICONV) \
+    $(LTLIBINTL)
+libini_config_la_LDFLAGS = \
     -version-info 7:1:2
 if HAVE_LD_VERSION_SCRIPT
 libini_config_la_LDFLAGS += -Wl,--version-script=$(top_srcdir)/ini/libini_config.sym

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,8 @@ dist_include_HEADERS += path_utils/path_utils.h
 
 libpath_utils_la_SOURCES = path_utils/path_utils.c
 libpath_utils_la_DEPENDENCIES = path_utils/libpath_utils.sym
+libpath_utils_la_LIBADD = $(LTLIBICONV) \
+    $(LTLIBINTL)
 libpath_utils_la_LDFLAGS = \
     -version-info 1:1:0
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,8 +65,11 @@ dist_include_HEADERS += path_utils/path_utils.h
 libpath_utils_la_SOURCES = path_utils/path_utils.c
 libpath_utils_la_DEPENDENCIES = path_utils/libpath_utils.sym
 libpath_utils_la_LDFLAGS = \
-    -version-info 1:1:0 \
-    -Wl,--version-script=$(top_srcdir)/path_utils/libpath_utils.sym
+    -version-info 1:1:0
+
+if HAVE_LD_VERSION_SCRIPT
+libpath_utils_la_LDFLAGS += -Wl,--version-script=$(top_srcdir)/path_utils/libpath_utils.sym
+endif
 
 if HAVE_CHECK
     check_PROGRAMS += path_utils_ut \
@@ -110,8 +113,10 @@ dist_include_HEADERS += dhash/dhash.h
 libdhash_la_SOURCES = dhash/dhash.c
 libdhash_la_DEPENDENCIES = dhash/libdhash.sym
 libdhash_la_LDFLAGS = \
-    -version-info 2:0:1 \
-    -Wl,--version-script=$(top_srcdir)/dhash/libdhash.sym
+    -version-info 2:0:1
+if HAVE_LD_VERSION_SCRIPT
+libdhash_la_LDFLAGS += -Wl,--version-script=$(top_srcdir)/dhash/libdhash.sym
+endif
 
 check_PROGRAMS += dhash_test dhash_example
 TESTS += dhash_test dhash_example
@@ -166,8 +171,10 @@ libcollection_la_SOURCES = \
     trace/trace.h
 libcollection_la_DEPENDENCIES = collection/libcollection.sym
 libcollection_la_LDFLAGS = \
-    -version-info 5:1:1 \
-    -Wl,--version-script=$(top_srcdir)/collection/libcollection.sym
+    -version-info 5:1:1
+if HAVE_LD_VERSION_SCRIPT
+libcollection_la_LDFLAGS += -Wl,--version-script=$(top_srcdir)/collection/libcollection.sym
+endif
 
 check_PROGRAMS += \
     collection_ut \
@@ -204,8 +211,10 @@ libref_array_la_SOURCES = \
     trace/trace.h
 libref_array_la_DEPENDENCIES = refarray/libref_array.sym
 libref_array_la_LDFLAGS = \
-    -version-info 3:1:2 \
-    -Wl,--version-script=$(top_srcdir)/refarray/libref_array.sym
+    -version-info 3:1:2
+if HAVE_LD_VERSION_SCRIPT
+libref_array_la_LDFLAGS += -Wl,--version-script=$(top_srcdir)/refarray/libref_array.sym
+endif
 
 check_PROGRAMS += ref_array_ut
 TESTS += ref_array_ut
@@ -233,8 +242,10 @@ libbasicobjects_la_SOURCES = \
     trace/trace.h
 libbasicobjects_la_DEPENDENCIES = basicobjects/libbasicobjects.sym
 libbasicobjects_la_LDFLAGS = \
-    -version-info 1:0:1 \
-    -Wl,--version-script=$(top_srcdir)/basicobjects/libbasicobjects.sym
+    -version-info 1:0:1
+if HAVE_LD_VERSION_SCRIPT
+libbasicobjects_la_LDFLAGS += -Wl,--version-script=$(top_srcdir)/basicobjects/libbasicobjects.sym
+endif
 
 check_PROGRAMS += simplebuffer_ut
 TESTS += simplebuffer_ut
@@ -291,9 +302,11 @@ libini_config_la_LIBADD = \
     libpath_utils.la \
     libref_array.la \
     libbasicobjects.la
-libini_config_la_LDFLAGS = \
-    -version-info 7:1:2 \
-    -Wl,--version-script=$(top_srcdir)/ini/libini_config.sym
+libini_config_la_LDFLAGS = -liconv -lintl \
+    -version-info 7:1:2
+if HAVE_LD_VERSION_SCRIPT
+libini_config_la_LDFLAGS += -Wl,--version-script=$(top_srcdir)/ini/libini_config.sym
+endif
 
 dist_noinst_DATA += \
     ini/ini.conf \

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,9 @@ RPMBUILD ?= $(PWD)/rpmbuild
 #Some old versions of automake don't define builddir
 builddir ?= .
 
+# Workaround for gettext whinging
+SUBDIRS =
+
 dist_noinst_DATA = \
     m4 \
     COPYING \
@@ -302,7 +305,7 @@ libini_config_la_LIBADD = \
     libpath_utils.la \
     libref_array.la \
     libbasicobjects.la
-libini_config_la_LDFLAGS = -liconv -lintl \
+libini_config_la_LDFLAGS = $(LIBICONV) $(LIBINTL)\
     -version-info 7:1:2
 if HAVE_LD_VERSION_SCRIPT
 libini_config_la_LDFLAGS += -Wl,--version-script=$(top_srcdir)/ini/libini_config.sym

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,7 @@ gl_LD_VERSION_SCRIPT
 
 AM_ICONV
 AM_GNU_GETTEXT
+# AM_GNU_GETTEXT_VERSION is specifically not called as otherwise we pull in all the rest of it's infrastructure, which isn't needed
 
 AC_CHECK_FUNC([strcasestr],
               AC_DEFINE([HAVE_STRCASESTR],

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,8 @@ AS_IF([test ["$trace_level" -gt "0"] -a ["$trace_level" -lt "8"] ],[AC_SUBST([TR
 AC_CHECK_SIZEOF([long])
 AC_CHECK_SIZEOF([long long])
 
+gl_LD_VERSION_SCRIPT
+
 AC_CHECK_FUNC([strcasestr],
               AC_DEFINE([HAVE_STRCASESTR],
                         [1],

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,9 @@ AC_CHECK_SIZEOF([long long])
 
 gl_LD_VERSION_SCRIPT
 
+AM_ICONV
+AM_GNU_GETTEXT
+
 AC_CHECK_FUNC([strcasestr],
               AC_DEFINE([HAVE_STRCASESTR],
                         [1],

--- a/m4/ld-version-script.m4
+++ b/m4/ld-version-script.m4
@@ -1,0 +1,48 @@
+# ld-version-script.m4 serial 4
+dnl Copyright (C) 2008-2016 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# FIXME: The test below returns a false positive for mingw
+# cross-compiles, 'local:' statements does not reduce number of
+# exported symbols in a DLL.  Use --disable-ld-version-script to work
+# around the problem.
+
+# gl_LD_VERSION_SCRIPT
+# --------------------
+# Check if LD supports linker scripts, and define automake conditional
+# HAVE_LD_VERSION_SCRIPT if so.
+AC_DEFUN([gl_LD_VERSION_SCRIPT],
+[
+  AC_ARG_ENABLE([ld-version-script],
+    [AS_HELP_STRING([--enable-ld-version-script],
+       [enable linker version script (default is enabled when possible)])],
+    [have_ld_version_script=$enableval],
+    [AC_CACHE_CHECK([if LD -Wl,--version-script works],
+       [gl_cv_sys_ld_version_script],
+       [gl_cv_sys_ld_version_script=no
+        save_LDFLAGS=$LDFLAGS
+        LDFLAGS="$LDFLAGS -Wl,--version-script=conftest.map"
+        echo foo >conftest.map
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+          [],
+          [cat > conftest.map <<EOF
+VERS_1 {
+        global: sym;
+};
+
+VERS_2 {
+        global: sym;
+} VERS_1;
+EOF
+           AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+             [gl_cv_sys_ld_version_script=yes])])
+        rm -f conftest.map
+        LDFLAGS=$save_LDFLAGS])
+     have_ld_version_script=$gl_cv_sys_ld_version_script])
+  AM_CONDITIONAL([HAVE_LD_VERSION_SCRIPT],
+    [test "$have_ld_version_script" = yes])
+])


### PR DESCRIPTION
This PR does the following:

* Makes ding-libs build on OS X
* Ignores all the extra build artifacts that aren't in source control (including from the tests)