### PR TITLE
path_utils_ut: allow single / as well

### DIFF
--- a/path_utils/path_utils_ut.c
+++ b/path_utils/path_utils_ut.c
@@ -62,7 +62,7 @@ START_TEST(test_dirname)
     fail_unless_str_equal(p, "//foo");
 
     fail_unless(get_dirname(p, PATH_MAX, "//foo//") == SUCCESS);
-    fail_unless_str_equal(p, "//");
+    fail_unless(!strcmp(p, "/") || !strcmp(p, "//"));
 
     fail_unless(get_dirname(p, PATH_MAX, "foo//bar") == SUCCESS);
     fail_unless_str_equal(p, "foo");


### PR DESCRIPTION
From http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap03.html#tag_03_266

> Multiple successive slashes are considered to be the same as one slash.

When running the tests on a musl libc system
 `get_dirname(p, PATH_MAX, "//foo//")`
actually results in a `/ `and not `//`