### PR TITLE
CONFIGURE: fix AM_GNU_GETTEXT usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ AC_CHECK_SIZEOF([long long])
 gl_LD_VERSION_SCRIPT
 
 AM_ICONV
-AM_GNU_GETTEXT
+AM_GNU_GETTEXT([external])
 # AM_GNU_GETTEXT_VERSION is specifically not called as otherwise we pull in all the rest of it's infrastructure, which isn't needed
 
 AC_CHECK_FUNC([strcasestr],

--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,7 @@ gl_LD_VERSION_SCRIPT
 
 AM_ICONV
 AM_GNU_GETTEXT([external])
-# AM_GNU_GETTEXT_VERSION is specifically not called as otherwise we pull in all the rest of it's infrastructure, which isn't needed
+AM_GNU_GETTEXT_VERSION([0.14.4])
 
 AC_CHECK_FUNC([strcasestr],
               AC_DEFINE([HAVE_STRCASESTR],


### PR DESCRIPTION
Fixed following autoreconf issue:
```
ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported
```